### PR TITLE
Parse numeric strings with thousand separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "msty",
+  "version": "1.0.0",
+  "description": "",
+  "main": "parseNumber.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/parseNumber.js
+++ b/parseNumber.js
@@ -1,0 +1,26 @@
+function parseNumber(input) {
+  if (typeof input !== 'string') {
+    return Number.parseFloat(input);
+  }
+  let cleaned = input.replace(/[\s_]/g, '');
+  const hasComma = cleaned.includes(',');
+  const hasDot = cleaned.includes('.');
+  if (hasComma) {
+    if (hasDot) {
+      // Assume commas are thousands separators
+      cleaned = cleaned.replace(/,/g, '');
+    } else {
+      const parts = cleaned.split(',');
+      if (parts.length === 2 && parts[1].length <= 2) {
+        // Single comma used as decimal separator
+        cleaned = parts[0] + '.' + parts[1];
+      } else {
+        // Commas are thousands separators
+        cleaned = parts.join('');
+      }
+    }
+  }
+  return Number.parseFloat(cleaned);
+}
+
+module.exports = parseNumber;

--- a/test/parseNumber.test.js
+++ b/test/parseNumber.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const parseNumber = require('../parseNumber');
+
+test('parses comma thousands with dot decimal', () => {
+  assert.strictEqual(parseNumber('1,234.56'), 1234.56);
+});
+
+test('parses space thousands with comma decimal', () => {
+  assert.strictEqual(parseNumber('1 234,56'), 1234.56);
+});
+
+test('parses underscore thousands', () => {
+  assert.strictEqual(parseNumber('1_234.56'), 1234.56);
+});


### PR DESCRIPTION
## Summary
- strip commas, spaces, and underscores from numeric input and handle decimal commas
- parse the cleaned string using `Number.parseFloat`
- add tests for comma, space, and underscore separated numbers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e2625f8832e85ad6a4d2fae4713